### PR TITLE
Update python-app.yaml - try fix for windows change

### DIFF
--- a/.github/workflows/python-app.yaml
+++ b/.github/workflows/python-app.yaml
@@ -22,10 +22,11 @@ jobs:
           python -m pip install --upgrade pip
           # pip install -r requirements.txt
           pip install .
-      - name: Install liblsl
+      - name: Install liblsl Unix  # should come with pylsl for windows
         run: |
           wget https://github.com/sccn/liblsl/releases/download/v1.16.2/liblsl-1.16.2-bionic_amd64.deb
           sudo apt install ./liblsl*.deb
+        continue-on-error: true
       - name: Lint with Ruff
         run: |
           pip install ruff

--- a/src/dareplane_utils/stream_watcher/lsl_stream_watcher.py
+++ b/src/dareplane_utils/stream_watcher/lsl_stream_watcher.py
@@ -1,5 +1,6 @@
 import ctypes
 import logging
+import os
 from typing import Callable
 
 import numpy as np
@@ -154,11 +155,17 @@ class StreamWatcher:
             ctypes.c_byte: np.int8,
             ctypes.c_short: np.int16,
             ctypes.c_int: np.int32,
-            ctypes.c_long: np.int64,
+            ctypes.c_longlong: np.int64,
         }
 
         # default to np.float32 << LSL default
         dtype = dtype_map.get(self.inlet.value_type, np.float32)
+
+        # Raise error if on Windows with int32
+        if os.name == "nt" and dtype == np.int32:
+            raise ValueError(
+                "Using int32 on Windows is not supported due to an open issue with pylsl. See https://github.com/labstreaminglayer/pylsl/issues/84"
+            )
 
         self.chunk_buffer = np.zeros(
             (self.chunk_buffer_size, len(self.channel_names))

--- a/tests/test_streamwatcher.py
+++ b/tests/test_streamwatcher.py
@@ -162,10 +162,15 @@ def test_data_format_derivation(fmt):
     outlet = pylsl.StreamOutlet(info)
 
     # Abort for windows as test will fail: https://github.com/labstreaminglayer/pylsl/issues/84
-    if os.name == "nt" and fmt == "int32":
-        with pytest.raises(ValueError):
-            sw = StreamWatcher(sname)
-            sw.connect_to_stream()
+    if os.name == "nt":
+        if fmt == "int32":
+            with pytest.raises(ValueError):
+                sw = StreamWatcher(sname)
+                sw.connect_to_stream()
+        if fmt == "int64":
+            with pytest.raises(NotImplementedError):
+                sw = StreamWatcher(sname)
+                sw.connect_to_stream()
     else:
         sw = StreamWatcher(sname)
         sw.connect_to_stream()


### PR DESCRIPTION
Trying to get github actions to test for several OS.
E.g. to catch different handling of `int64` in the StreamWatcher, which seems to work on unix with pylsl, but on windows, LSL is using a `c_longlong` 