### PR TITLE
Implement ModuleConnection class to handle startup and communication with (external) modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This currently includes:
 1. A `DefaultServer` - which will be loaded an extended within each module to implement the dareplane API
 1. `logging` - which contains the standard formatting and a SocketHandler which is modified to send `json` representations of the logging records to the default logging server port (9020). This is used to enable cross process logging.
 1. A `StreamWatcher` implementation - which is a utility class to query a single LSL stream into a ring buffer.
+1. A `ModuleConnection` - which, together with a `launcher` and `communicator`, is used to launch and interact with other modules (currently supports launching Python and .exe programs).
 
 ## Default Dareplane Server
 

--- a/src/dareplane_utils/default_server/server.py
+++ b/src/dareplane_utils/default_server/server.py
@@ -131,6 +131,9 @@ class DefaultServer:
                     msg = self.current_conn.recv(2048)
                     if msg:
                         self.handle_msg(msg)
+                    else:
+                        self.logger.info("Client disconnected")
+                        break
 
                 except socket.timeout as err:
                     self.logger.info(f"Caugth timeout error {err=}")
@@ -143,9 +146,8 @@ class DefaultServer:
                         f"Was unable to decode {msg=} to ascii\n".encode()  # type: ignore
                     )
                 except ConnectionResetError as err:
-                    self.logger.info("Connection was reset by host- stopping the server")
-                    self.is_listening = False
-                    raise err
+                    self.logger.info("Connection was reset by host")
+                    break
                 except Exception as err:
                     self.logger.error(f"Caught error {err=}")
                     self.is_listening = False

--- a/src/dareplane_utils/module_handling/communication.py
+++ b/src/dareplane_utils/module_handling/communication.py
@@ -1,0 +1,177 @@
+from abc import ABC, abstractmethod
+from socket import SHUT_RDWR
+import socket
+import time
+
+from subprocess import Popen
+
+class Communicator(ABC):
+    """Base class for communication with modules"""
+    
+    @abstractmethod
+    def connect(self) -> None:
+        pass
+    
+    @abstractmethod
+    def disconnect(self) -> None:
+        pass
+    
+    @abstractmethod
+    def send(self, data: bytes) -> None:
+        pass
+    
+    @abstractmethod
+    def receive(self, size: int) -> bytes:
+        pass
+
+
+class SocketCommunicator(Communicator):
+    def __init__(self, ip: str, port: int, name: str, 
+                 retry_after_s: float = 1, max_connect_retries: int = 3, logger=None):
+        self.ip = ip
+        self.port = port
+        self.name = name
+        self.retry_after_s = retry_after_s
+        self.max_connect_retries = max_connect_retries
+        self.logger = logger
+        self.socket_c = None
+        self.near_port = 0
+    
+    def connect(self):
+        if self.logger:
+            self.logger.debug(f"{self.name=} - connecting socket to {self.ip}:{self.port}")
+
+        try:
+            self.socket_c = self.create_socket_client(
+                host_ip=self.ip,
+                port=self.port,
+                retry_connection_after_s=self.retry_after_s,
+            )
+        except ConnectionRefusedError as err:
+            if self.logger:
+                self.logger.debug(
+                    f"{self.name=}- Cannot connect to socket at {self.ip}:{self.port}. Connection refused."
+                )
+            raise err
+
+        # Time-out as non of the sockets should block indefinitely
+        self.socket_c.setblocking(0)
+
+        # read out the actual socket -> if port == 0, a random free port
+        # was assigned
+        self.near_port = self.socket_c.getsockname()[1]
+
+        # There might be a response / confirmation of the connetion
+        try:
+            self.socket_c.settimeout(1)
+            # msg = self.socket_c.recv(2048 * 8)
+            fragments = []
+            while True:
+                chunk = self.socket_c.recv(1024)
+                if not chunk:
+                    break
+                fragments.append(chunk)
+            msg = b"".join(fragments)
+
+            if self.logger:
+                self.logger.debug(f"connection returned: {msg.decode()}")
+            self.socket_c.settimeout(None)
+        except ConnectionResetError as err:
+            if self.logger:
+                self.logger.debug(
+                    f"Connection refused for - {self.name=}, {self.ip=}, {self.port=}"
+                )
+            raise err
+        except TimeoutError as err:
+            if self.logger:
+                self.logger.debug(f"No response upon connection for {self.name=} - {err=}")
+        except Exception as err:
+            if self.logger:
+                self.logger.debug(f"Other error upon connection for {self.name=}, {err=}")
+            raise err
+    
+    def create_socket_client(
+            self, host_ip: str, port: int, retry_connection_after_s: float = 1
+        ) -> socket.socket:
+        """
+        Create a socket client and attempt to connect to a specified host and port.
+
+        This function attempts to establish a TCP connection to the specified host and port.
+        It retries the connection up to a maximum number of times (3) if the connection is refused.
+        If the connection is successful, the socket object is returned.
+
+        Parameters
+        ----------
+        host_ip : str
+            The IP address of the host to connect to.
+        port : int
+            The port number on the host to connect to.
+        retry_connection_after_s : float, optional
+            The number of seconds to wait between connection attempts, by default 1.
+
+        Returns
+        -------
+        socket.socket
+            A socket object representing the connection to the host.
+
+        Raises
+        ------
+        ConnectionRefusedError
+            If the connection is refused after the maximum number of 3 retries.
+        """
+        conn_try = 0
+        while conn_try < self.max_connect_retries:
+            try:
+                if self.logger:
+                    self.logger.debug(f"Trying connection to: {host_ip=}, {port=}")
+                s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                s.connect((host_ip, port))
+                if self.logger:
+                    self.logger.debug(f"Connected to: {host_ip=}, {port=} using {s=}")
+                return s
+            except ConnectionRefusedError:
+                if self.logger:
+                    self.logger.debug(
+                        f"Connection refused for - {self.name=}, {host_ip=}, {port=}. Retrying in {retry_connection_after_s} seconds..."
+                    )
+
+                # Close the socket and start fresh as otherwise
+                # we will get a an Errno 22 in the second try
+                s.close()
+
+                time.sleep(retry_connection_after_s)
+                pass
+            conn_try += 1
+
+        raise ConnectionRefusedError(
+            f"Connection refused after {self.max_connect_retries} tries: {host_ip=}, {port=}"
+        )
+    
+    def disconnect(self) -> None:
+        if not self.socket_c:
+            return
+        try:
+            if self.logger:
+                self.logger.debug(f"{self.name} trying to gracefully shurtdown {self.socket_c}")
+            self.socket_c.shutdown(SHUT_RDWR)
+        except OSError:
+            if self.logger:
+                self.logger.debug(
+                    f"{self.name} caught OSError on connection.shutdown"
+                    " - connection already closed?"
+                )
+        finally:
+            try:
+                self.socket_c.close()
+            except OSError:
+                pass
+            self.socket_c = None
+                
+    def send(self, data: bytes) -> None:
+        if self.socket_c:
+            self.socket_c.sendall(data)
+    
+    def receive(self, size: int) -> bytes:
+        if self.socket_c:
+            return self.socket_c.recv(size)
+        return b""

--- a/src/dareplane_utils/module_handling/launcher.py
+++ b/src/dareplane_utils/module_handling/launcher.py
@@ -3,7 +3,7 @@ from subprocess import Popen
 from pathlib import Path
 import os
 import subprocess
-from time import time
+import time
 import sys
 
 import psutil

--- a/src/dareplane_utils/module_handling/launcher.py
+++ b/src/dareplane_utils/module_handling/launcher.py
@@ -10,16 +10,28 @@ import psutil
 
 
 class Launcher(ABC):
-    """Base class for launching different types of processes"""
+    """Base class for launching different types of processes."""
     
     @abstractmethod
     def launch(self) -> Popen:
-        """Launch the process, return Popen"""
+        """Launch the process.
+
+        Returns
+        -------
+        subprocess.Popen
+            Handle to the launched process.
+        """
         pass
     
     @abstractmethod
     def terminate(self, process: Popen) -> None:
-        """Clean up the process"""
+        """Terminate and clean up a launched process.
+
+        Parameters
+        ----------
+        process : subprocess.Popen
+            Process handle to terminate.
+        """
         pass
 
 
@@ -32,14 +44,21 @@ class PythonLauncher(Launcher):
         args: list[str] | None = None,
         kwargs: dict | None = None,
     ):
-        """Launch a Python module as a subprocess
-        
-        Args:
-            entry_point: Python module entry point for `python -m <entry_point>`
-            cwd: Working directory for launching the process
-            executable: Python executable to use (default: current Python). Can be a path to a specific Python interpreter or environment.
-            args: Additional positional arguments to pass to the module invocation
-            kwargs: Additional keyword arguments to pass as --key=value
+        """Initialize a launcher for Python module subprocesses.
+
+        Parameters
+        ----------
+        entry_point : str
+            Python module entry point for ``python -m <entry_point>``.
+        cwd : pathlib.Path
+            Working directory used when launching the subprocess.
+        executable : str, optional
+            Python executable to use. Defaults to the current interpreter.
+            This can be a path to a specific Python environment.
+        args : list of str or None, optional
+            Additional positional arguments passed to module invocation.
+        kwargs : dict or None, optional
+            Additional keyword arguments passed as ``--key=value``.
         """
         self.executable = executable
         self.entry_point = entry_point
@@ -75,11 +94,17 @@ class PythonLauncher(Launcher):
 
 class ExeLauncher(Launcher):
     def __init__(self, exe_path: Path, args: list | None = None, cwd: Path | None = None):
-        """Launch a generic executable as a subprocess
-        
-        Args:
-            exe_path: Path to the executable to launch
-            args: List of arguments to pass to the executable
+        """Initialize a launcher for generic executables.
+
+        Parameters
+        ----------
+        exe_path : pathlib.Path
+            Path to the executable to launch.
+        args : list or None, optional
+            Arguments passed to the executable.
+        cwd : pathlib.Path or None, optional
+            Working directory for the subprocess. If ``None``, the current
+            process working directory is used.
         """
         self.exe_path = exe_path
         self.args = args or []
@@ -98,8 +123,14 @@ class ExeLauncher(Launcher):
         if process:
             close_process_and_child_processes(process)
     
-def close_process_and_child_processes(process: subprocess.Popen) -> int:
-    """Close a process and its child processes"""
+def close_process_and_child_processes(process: subprocess.Popen) -> None:
+    """Close a process and its child processes.
+
+    Parameters
+    ----------
+    process : subprocess.Popen
+        Parent process to terminate.
+    """
     try:
         parent_ps = psutil.Process(process.pid)
     except psutil.NoSuchProcess:
@@ -133,5 +164,3 @@ def close_process_and_child_processes(process: subprocess.Popen) -> int:
         parent_ps.kill()
     except:
         pass
-    return 0
-

--- a/src/dareplane_utils/module_handling/launcher.py
+++ b/src/dareplane_utils/module_handling/launcher.py
@@ -158,11 +158,16 @@ def close_process_and_child_processes(process: subprocess.Popen) -> None:
         for ch in children:
             try:
                 ch.terminate()
+                try:
+                    ch.wait(timeout=1)
+                except psutil.TimeoutExpired:
+                    ch.kill()
             except:
                 pass
         i += 1
 
+    parent_ps.terminate()
     try:
+        parent_ps.wait(timeout=1)
+    except psutil.TimeoutExpired:
         parent_ps.kill()
-    except:
-        pass

--- a/src/dareplane_utils/module_handling/launcher.py
+++ b/src/dareplane_utils/module_handling/launcher.py
@@ -1,0 +1,137 @@
+from abc import ABC, abstractmethod
+from subprocess import Popen
+from pathlib import Path
+import os
+import subprocess
+from time import time
+import sys
+
+import psutil
+
+
+class Launcher(ABC):
+    """Base class for launching different types of processes"""
+    
+    @abstractmethod
+    def launch(self) -> Popen:
+        """Launch the process, return Popen"""
+        pass
+    
+    @abstractmethod
+    def terminate(self, process: Popen) -> None:
+        """Clean up the process"""
+        pass
+
+
+class PythonLauncher(Launcher):
+    def __init__(
+        self,
+        entry_point: str,
+        cwd: Path,
+        executable: str = sys.executable,
+        args: list[str] | None = None,
+        kwargs: dict | None = None,
+    ):
+        """Launch a Python module as a subprocess
+        
+        Args:
+            entry_point: Python module entry point for `python -m <entry_point>`
+            cwd: Working directory for launching the process
+            executable: Python executable to use (default: current Python). Can be a path to a specific Python interpreter or environment.
+            args: Additional positional arguments to pass to the module invocation
+            kwargs: Additional keyword arguments to pass as --key=value
+        """
+        self.executable = executable
+        self.entry_point = entry_point
+        self.args = args or []
+        self.kwargs = kwargs or {}
+        self.cwd = cwd
+    
+    def launch(self) -> Popen:
+        modpath = self.cwd
+
+        assert modpath.exists(), f"not a valid path {modpath}"
+
+        cmd = [
+            self.executable,
+            "-m",
+            self.entry_point,
+            *self.args,
+            *[f"--{k}={v}" for k, v in self.kwargs.items()],
+        ]
+
+        popen_kwargs = {"cwd": str(modpath.resolve())}
+        if os.name == "nt":
+            popen_kwargs["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP
+        else:
+            popen_kwargs["start_new_session"] = True
+
+        return subprocess.Popen(cmd, **popen_kwargs)
+    
+    def terminate(self, process: Popen) -> None:
+        if process:
+            close_process_and_child_processes(process)
+
+
+class ExeLauncher(Launcher):
+    def __init__(self, exe_path: Path, args: list | None = None, cwd: Path | None = None):
+        """Launch a generic executable as a subprocess
+        
+        Args:
+            exe_path: Path to the executable to launch
+            args: List of arguments to pass to the executable
+        """
+        self.exe_path = exe_path
+        self.args = args or []
+        self.cwd = cwd
+    
+    def launch(self) -> Popen:
+        popen_kwargs = {"cwd": str(self.cwd) if self.cwd else None}
+        if os.name == "nt":
+            popen_kwargs["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP
+        else:
+            popen_kwargs["start_new_session"] = True
+
+        return subprocess.Popen([str(self.exe_path)] + self.args, **popen_kwargs)
+    
+    def terminate(self, process: Popen) -> None:
+        if process:
+            close_process_and_child_processes(process)
+    
+def close_process_and_child_processes(process: subprocess.Popen) -> int:
+    """Close a process and its child processes"""
+    try:
+        parent_ps = psutil.Process(process.pid)
+    except psutil.NoSuchProcess:
+        return 0
+
+    max_iter = 5
+    i = 0
+
+    while i <= max_iter:
+        if i > 0:
+            time.sleep(0.2)
+        try:
+            children = parent_ps.children()
+        except psutil.NoSuchProcess:
+            # Parent process is gone, so we are done
+            return 0
+
+        # If no children, break
+        if children == []:
+            break
+
+        # Otherwise, try to terminate children
+        for ch in children:
+            try:
+                ch.terminate()
+            except:
+                pass
+        i += 1
+
+    try:
+        parent_ps.kill()
+    except:
+        pass
+    return 0
+

--- a/src/dareplane_utils/module_handling/launcher.py
+++ b/src/dareplane_utils/module_handling/launcher.py
@@ -39,7 +39,7 @@ class PythonLauncher(Launcher):
     def __init__(
         self,
         entry_point: str,
-        cwd: Path,
+        cwd: Path | str,
         executable: str = sys.executable,
         args: list[str] | None = None,
         kwargs: dict | None = None,
@@ -50,7 +50,7 @@ class PythonLauncher(Launcher):
         ----------
         entry_point : str
             Python module entry point for ``python -m <entry_point>``.
-        cwd : pathlib.Path
+        cwd : pathlib.Path or str
             Working directory used when launching the subprocess.
         executable : str, optional
             Python executable to use. Defaults to the current interpreter.
@@ -64,6 +64,8 @@ class PythonLauncher(Launcher):
         self.entry_point = entry_point
         self.args = args or []
         self.kwargs = kwargs or {}
+        if isinstance(cwd, str):
+            cwd = Path(cwd)
         self.cwd = cwd
     
     def launch(self) -> Popen:

--- a/src/dareplane_utils/module_handling/launcher.py
+++ b/src/dareplane_utils/module_handling/launcher.py
@@ -14,13 +14,15 @@ class Launcher(ABC):
     """Base class for launching different types of processes."""
     
     @abstractmethod
-    def launch(self, relaunch: bool = False) -> Popen:
+    def launch(self, relaunch: bool = False, **kwargs) -> Popen:
         """Launch the process.
 
         Parameters
         ----------
         relaunch : bool, optional
             If ``True``, will terminate an existing process before launching a new one. Defaults to ``False``.
+        **kwargs
+            Additional keyword arguments passed to ``subprocess.Popen``.
 
         Returns
         -------
@@ -71,7 +73,7 @@ class PythonLauncher(Launcher):
         
         assert self.cwd.exists(), f"Directory {self.cwd} does not exist"
     
-    def launch(self, relaunch: bool = False) -> Popen:
+    def launch(self, relaunch: bool = False, **popen_kwargs) -> Popen:
         if self.process and not relaunch:
             warnings.warn(
                     f"Module {self.name=} is already running with pid {self.process.pid}. Returning existing process.",
@@ -92,7 +94,7 @@ class PythonLauncher(Launcher):
             *[f"--{k}={v}" for k, v in self.kwargs.items()],
         ]
 
-        popen_kwargs = {"cwd": str(self.cwd.resolve())}
+        popen_kwargs["cwd"] = str(self.cwd.resolve())
         if os.name == "nt":
             popen_kwargs["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP
         else:
@@ -108,7 +110,7 @@ class PythonLauncher(Launcher):
 
 
 class ExeLauncher(Launcher):
-    def __init__(self, exe_path: Path, args: list | None = None, cwd: Path | None = None):
+    def __init__(self, exe_path: Path | str, args: list | None = None, cwd: Path | str | None = None):
         """Initialize a launcher for generic executables.
 
         Parameters
@@ -121,16 +123,22 @@ class ExeLauncher(Launcher):
             Working directory for the subprocess. If ``None``, the current
             process working directory is used.
         """
+        if isinstance(exe_path, str):
+            exe_path = Path(exe_path)
+        if isinstance(cwd, str):
+            cwd = Path(cwd)
         self.exe_path = exe_path
         self.args = args or []
         self.cwd = cwd
         self.process = None
+        if self.cwd is None:
+            self.cwd = Path.cwd()
 
         assert self.cwd.exists(), f"Directory {self.cwd} does not exist"
         assert self.exe_path.exists(), f"Executable {self.exe_path} does not exist"
         
     
-    def launch(self, relaunch: bool = False) -> Popen:
+    def launch(self, relaunch: bool = False, **popen_kwargs) -> Popen:
         if self.process and not relaunch:
             warnings.warn(
                     f"Module {self.name=} is already running with pid {self.process.pid}. Returning existing process.",
@@ -143,7 +151,7 @@ class ExeLauncher(Launcher):
             self.terminate()
             self.process = None
 
-        popen_kwargs = {"cwd": str(self.cwd) if self.cwd else None}
+        popen_kwargs["cwd"] = str(self.cwd) if self.cwd else None
         if os.name == "nt":
             popen_kwargs["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP
         else:

--- a/src/dareplane_utils/module_handling/launcher.py
+++ b/src/dareplane_utils/module_handling/launcher.py
@@ -5,6 +5,7 @@ import os
 import subprocess
 import time
 import sys
+import warnings
 
 import psutil
 
@@ -13,8 +14,13 @@ class Launcher(ABC):
     """Base class for launching different types of processes."""
     
     @abstractmethod
-    def launch(self) -> Popen:
+    def launch(self, relaunch: bool = False) -> Popen:
         """Launch the process.
+
+        Parameters
+        ----------
+        relaunch : bool, optional
+            If ``True``, will terminate an existing process before launching a new one. Defaults to ``False``.
 
         Returns
         -------
@@ -24,14 +30,8 @@ class Launcher(ABC):
         pass
     
     @abstractmethod
-    def terminate(self, process: Popen) -> None:
-        """Terminate and clean up a launched process.
-
-        Parameters
-        ----------
-        process : subprocess.Popen
-            Process handle to terminate.
-        """
+    def terminate(self) -> None:
+        """Terminate and clean up a launched process."""
         pass
 
 
@@ -60,6 +60,7 @@ class PythonLauncher(Launcher):
         kwargs : dict or None, optional
             Additional keyword arguments passed as ``--key=value``.
         """
+        self.process = None
         self.executable = executable
         self.entry_point = entry_point
         self.args = args or []
@@ -67,11 +68,21 @@ class PythonLauncher(Launcher):
         if isinstance(cwd, str):
             cwd = Path(cwd)
         self.cwd = cwd
+        
+        assert self.cwd.exists(), f"Directory {self.cwd} does not exist"
     
-    def launch(self) -> Popen:
-        modpath = self.cwd
-
-        assert modpath.exists(), f"not a valid path {modpath}"
+    def launch(self, relaunch: bool = False) -> Popen:
+        if self.process and not relaunch:
+            warnings.warn(
+                    f"Module {self.name=} is already running with pid {self.process.pid}. Returning existing process.",
+                    RuntimeWarning,
+                    stacklevel=2
+                )
+            return self.process
+        
+        if self.process and relaunch:
+            self.terminate()
+            self.process = None
 
         cmd = [
             self.executable,
@@ -81,17 +92,19 @@ class PythonLauncher(Launcher):
             *[f"--{k}={v}" for k, v in self.kwargs.items()],
         ]
 
-        popen_kwargs = {"cwd": str(modpath.resolve())}
+        popen_kwargs = {"cwd": str(self.cwd.resolve())}
         if os.name == "nt":
             popen_kwargs["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP
         else:
             popen_kwargs["start_new_session"] = True
 
-        return subprocess.Popen(cmd, **popen_kwargs)
-    
-    def terminate(self, process: Popen) -> None:
-        if process:
-            close_process_and_child_processes(process)
+        self.process = subprocess.Popen(cmd, **popen_kwargs)
+        return self.process
+
+    def terminate(self) -> None:
+        if self.process:
+            close_process_and_child_processes(self.process)
+            self.process = None
 
 
 class ExeLauncher(Launcher):
@@ -111,20 +124,40 @@ class ExeLauncher(Launcher):
         self.exe_path = exe_path
         self.args = args or []
         self.cwd = cwd
+        self.process = None
+
+        assert self.cwd.exists(), f"Directory {self.cwd} does not exist"
+        assert self.exe_path.exists(), f"Executable {self.exe_path} does not exist"
+        
     
-    def launch(self) -> Popen:
+    def launch(self, relaunch: bool = False) -> Popen:
+        if self.process and not relaunch:
+            warnings.warn(
+                    f"Module {self.name=} is already running with pid {self.process.pid}. Returning existing process.",
+                    RuntimeWarning,
+                    stacklevel=2
+                )
+            return self.process
+        
+        if self.process and relaunch:
+            self.terminate()
+            self.process = None
+
         popen_kwargs = {"cwd": str(self.cwd) if self.cwd else None}
         if os.name == "nt":
             popen_kwargs["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP
         else:
             popen_kwargs["start_new_session"] = True
 
-        return subprocess.Popen([str(self.exe_path)] + self.args, **popen_kwargs)
+        self.process = subprocess.Popen([str(self.exe_path)] + self.args, **popen_kwargs)
+        return self.process
     
-    def terminate(self, process: Popen) -> None:
-        if process:
-            close_process_and_child_processes(process)
-    
+    def terminate(self) -> None:
+        if self.process:
+            close_process_and_child_processes(self.process)
+            self.process = None
+
+
 def close_process_and_child_processes(process: subprocess.Popen) -> None:
     """Close a process and its child processes.
 

--- a/src/dareplane_utils/module_handling/module_connection.py
+++ b/src/dareplane_utils/module_handling/module_connection.py
@@ -13,7 +13,6 @@ class ModuleConnection:
     launcher: Launcher
     communicator: Communicator | None = None
     pcomms: list[str] = field(default_factory=list)
-    module_kind: str = ""
     process: Popen | None = None
 
     @property

--- a/src/dareplane_utils/module_handling/module_connection.py
+++ b/src/dareplane_utils/module_handling/module_connection.py
@@ -12,14 +12,6 @@ class ModuleConnection:
     name: str
     launcher: Launcher
     communicator: Communicator | None = None
-    pcomms: list[str] = field(default_factory=list)
-    process: Popen | None = None
-
-    @property
-    def socket_c(self):
-        if self.communicator and hasattr(self.communicator, "socket_c"):
-            return self.communicator.socket_c
-        return None
 
     def start_module_server(self):
         self.process = self.launcher.launch()
@@ -46,16 +38,11 @@ class ModuleConnection:
             self.launcher.terminate(self.process)
             self.process = None
 
-    def get_pcommands(self):
-        if self.socket_c is None:
-            return
-
-        self.socket_c.sendall(b"GET_PCOMMS")
-        time.sleep(0.1)
-        msg = self.socket_c.recv(2048 * 8)
-        decoded = msg.decode().strip()
-        if decoded:
-            self.pcomms = decoded.split("|")
+    def send_message(self, msg: bytes):
+        if self.communicator:
+            self.communicator.send(msg)
+        else:
+            raise ConnectionError(f"Cannot send message to module {self.name=} because it has no communicator")
     
     def start(self):
         """Start the module and establish communication"""

--- a/src/dareplane_utils/module_handling/module_connection.py
+++ b/src/dareplane_utils/module_handling/module_connection.py
@@ -4,7 +4,7 @@ import time
 from subprocess import Popen
 
 from dareplane_utils.module_handling.launcher import Launcher
-from dareplane_utils.module_handling.communication import Communicator
+from dareplane_utils.module_handling.communication import Communicator, SocketCommunicator
     
 @dataclass
 class ModuleConnection:
@@ -43,7 +43,13 @@ class ModuleConnection:
             self.communicator.send(msg)
         else:
             raise ConnectionError(f"Cannot send message to module {self.name=} because it has no communicator")
-    
+        
+    def receive_message(self, size: int) -> bytes:
+        if isinstance(self.communicator, SocketCommunicator):
+            return self.communicator.receive(size)
+        else:
+            raise NotImplementedError(f"Receive message is only implemented for SocketCommunicator, but have {type(self.communicator)}")
+
     def start(self):
         """Start the module and establish communication"""
         self.start_module_server()

--- a/src/dareplane_utils/module_handling/module_connection.py
+++ b/src/dareplane_utils/module_handling/module_connection.py
@@ -1,0 +1,75 @@
+from dataclasses import dataclass
+from dataclasses import field
+import time
+from subprocess import Popen
+
+from dareplane_utils.module_handling.launcher import Launcher
+from dareplane_utils.module_handling.communication import Communicator
+    
+@dataclass
+class ModuleConnection:
+    """A class to manage the connection to a module, including launching the module and communicating with it."""
+    name: str
+    launcher: Launcher
+    communicator: Communicator | None = None
+    pcomms: list[str] = field(default_factory=list)
+    module_kind: str = ""
+    process: Popen | None = None
+
+    @property
+    def socket_c(self):
+        if self.communicator and hasattr(self.communicator, "socket_c"):
+            return self.communicator.socket_c
+        return None
+
+    def start_module_server(self):
+        self.process = self.launcher.launch()
+
+    def connect_to_module(self):
+        if self.communicator:
+            try:
+                self.communicator.connect()
+            except ConnectionRefusedError as e:
+                    # If connection failed because host process is not running, give a more specific error
+                    if self.process is not None and self.process.poll() is not None:
+                        raise ConnectionRefusedError(
+                            f"Cannot connect to module {self.name=} at {self.ip}:{self.port}. Host process not running."
+                        )
+                    else:
+                        raise e
+
+    def stop_connection(self):
+        if self.communicator:
+            self.communicator.disconnect()
+
+    def stop_process(self):
+        if self.process is not None:
+            self.launcher.terminate(self.process)
+            self.process = None
+
+    def get_pcommands(self):
+        if self.socket_c is None:
+            return
+
+        self.socket_c.sendall(b"GET_PCOMMS")
+        time.sleep(0.1)
+        msg = self.socket_c.recv(2048 * 8)
+        decoded = msg.decode().strip()
+        if decoded:
+            self.pcomms = decoded.split("|")
+    
+    def start(self):
+        """Start the module and establish communication"""
+        self.start_module_server()
+        self.connect_to_module()
+    
+    def stop(self):
+        """Stop communication and terminate process"""
+        self.stop_connection()
+        self.stop_process()
+    
+    def __del__(self):
+        try:
+            self.stop()
+        except:
+            pass

--- a/src/dareplane_utils/module_handling/module_connection.py
+++ b/src/dareplane_utils/module_handling/module_connection.py
@@ -24,7 +24,7 @@ class ModuleConnection:
                     # If connection failed because host process is not running, give a more specific error
                     if self.process is not None and self.process.poll() is not None:
                         raise ConnectionRefusedError(
-                            f"Cannot connect to module {self.name=} at {self.ip}:{self.port}. Host process not running."
+                            f"Cannot connect to module {self.name=}. Host process not running."
                         )
                     else:
                         raise e

--- a/src/dareplane_utils/module_handling/module_connection.py
+++ b/src/dareplane_utils/module_handling/module_connection.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from dataclasses import field
-import time
 from subprocess import Popen
+import warnings
 
 from dareplane_utils.module_handling.launcher import Launcher
 from dareplane_utils.module_handling.communication import Communicator, SocketCommunicator
@@ -12,8 +12,16 @@ class ModuleConnection:
     name: str
     launcher: Launcher
     communicator: Communicator | None = None
+    process: Popen | None = None
 
     def start_module_server(self):
+        if self.process is not None and self.process.poll() is None:
+            warnings.warn(
+                    f"Module {self.name=} is already running with pid {self.process.pid}. Not launching again.",
+                    RuntimeWarning,
+                    stacklevel=2
+                )
+            return
         self.process = self.launcher.launch()
 
     def connect_to_module(self):

--- a/src/dareplane_utils/module_handling/module_connection.py
+++ b/src/dareplane_utils/module_handling/module_connection.py
@@ -1,7 +1,4 @@
 from dataclasses import dataclass
-from dataclasses import field
-from subprocess import Popen
-import warnings
 
 from dareplane_utils.module_handling.launcher import Launcher
 from dareplane_utils.module_handling.communication import Communicator, SocketCommunicator
@@ -12,17 +9,9 @@ class ModuleConnection:
     name: str
     launcher: Launcher
     communicator: Communicator | None = None
-    process: Popen | None = None
 
-    def start_module_server(self):
-        if self.process is not None and self.process.poll() is None:
-            warnings.warn(
-                    f"Module {self.name=} is already running with pid {self.process.pid}. Not launching again.",
-                    RuntimeWarning,
-                    stacklevel=2
-                )
-            return
-        self.process = self.launcher.launch()
+    def start_module_server(self, relaunch: bool = False):
+        self.launcher.launch(relaunch=relaunch)
 
     def connect_to_module(self):
         if self.communicator:
@@ -30,7 +19,7 @@ class ModuleConnection:
                 self.communicator.connect()
             except ConnectionRefusedError as e:
                     # If connection failed because host process is not running, give a more specific error
-                    if self.process is not None and self.process.poll() is not None:
+                    if self.launcher.process is not None and self.launcher.process.poll() is not None:
                         raise ConnectionRefusedError(
                             f"Cannot connect to module {self.name=}. Host process not running."
                         )
@@ -42,9 +31,7 @@ class ModuleConnection:
             self.communicator.disconnect()
 
     def stop_process(self):
-        if self.process is not None:
-            self.launcher.terminate(self.process)
-            self.process = None
+        self.launcher.terminate()
 
     def send_message(self, msg: bytes):
         if self.communicator:

--- a/src/dareplane_utils/module_handling/module_connection.py
+++ b/src/dareplane_utils/module_handling/module_connection.py
@@ -10,8 +10,8 @@ class ModuleConnection:
     launcher: Launcher
     communicator: Communicator | None = None
 
-    def start_module_server(self, relaunch: bool = False):
-        self.launcher.launch(relaunch=relaunch)
+    def launch_module(self, relaunch: bool = False, **popen_kwargs):
+        self.launcher.launch(relaunch=relaunch, **popen_kwargs)
 
     def connect_to_module(self):
         if self.communicator:
@@ -45,9 +45,9 @@ class ModuleConnection:
         else:
             raise NotImplementedError(f"Receive message is only implemented for SocketCommunicator, but have {type(self.communicator)}")
 
-    def start(self):
+    def start(self, relaunch: bool = False, **popen_kwargs):
         """Start the module and establish communication"""
-        self.start_module_server()
+        self.launch_module(relaunch=relaunch, **popen_kwargs)
         self.connect_to_module()
     
     def stop(self):

--- a/tests/resources/configurable_server.py
+++ b/tests/resources/configurable_server.py
@@ -1,0 +1,38 @@
+# A server implementation for testing purposes only
+
+import threading
+import argparse
+
+from dareplane_utils.default_server.server import DefaultServer
+from dareplane_utils.logging.logger import get_logger
+from fire import Fire
+
+logger = get_logger("testlogger")
+logger.setLevel(10)
+
+def run_server(
+    port: int = 8080,
+    ip: str = "127.0.0.1",
+    loglevel: int = 10,
+    command_name: str = "TEST",
+    stop_event: threading.Event = threading.Event(),
+):
+    logger.setLevel(loglevel)
+
+    pcommand_map = {
+        "GET_PCOMMS": "START|INIT|STOP|RUN_BLOCK",
+        command_name: lambda: print(f"{command_name} received."),
+    }
+
+    server = DefaultServer(port=port, ip=ip, pcommand_map=pcommand_map, name="control_room")
+
+    # initialize to start the socket
+    server.init_server(stop_event=stop_event)
+    # start processing of the server
+    logger.info("Server will start listening")
+    server.start_listening()
+
+    return 0
+
+if __name__ == "__main__":
+    Fire(run_server)

--- a/tests/resources/slow_test_server.py
+++ b/tests/resources/slow_test_server.py
@@ -1,0 +1,39 @@
+import threading
+import time
+
+from dareplane_utils.default_server.server import DefaultServer
+from dareplane_utils.logging.logger import get_logger
+from fire import Fire
+
+
+logger = get_logger("testlogger")
+logger.setLevel(10)
+
+def run_slow_startup_server(
+    port: int = 8081,
+    ip: str = "127.0.0.1",
+    loglevel: int = 10,
+    stop_event: threading.Event = threading.Event(),
+):
+    logger.setLevel(loglevel)
+
+    pcommand_map = {
+        "SLOWSERVERTEST": lambda x: print("SLOWSERVERTEST"),
+    }
+
+    server = DefaultServer(port, ip=ip, pcommand_map=pcommand_map, name="control_room")
+
+    time.sleep(5)  # have this delay to test with a very slow server
+    logger.info("Slow server will start listening")
+
+    # initialize to start the socket
+    server.init_server(stop_event=stop_event)
+
+    # start processing of the server
+    server.start_listening()
+
+    return 0
+
+if __name__ == "__main__":
+    logger.setLevel(10)
+    Fire(run_slow_startup_server)

--- a/tests/resources/test_server.py
+++ b/tests/resources/test_server.py
@@ -1,0 +1,42 @@
+# A server implementation for testing purposes only
+
+import threading
+
+from dareplane_utils.default_server.server import DefaultServer
+from dareplane_utils.logging.logger import get_logger
+from fire import Fire
+
+logger = get_logger("testlogger")
+logger.setLevel(10)
+
+def test_print() -> int:
+    logger.info("STARTING PRESSED")
+    return 0
+
+
+def run_server(
+    port: int = 8080,
+    ip: str = "127.0.0.1",
+    loglevel: int = 10,
+    stop_event: threading.Event = threading.Event(),
+):
+    logger.setLevel(loglevel)
+
+    pcommand_map = {
+        "START": test_print,  # note: that this will return a thread and an according stop_event, the default server will be able to do the bookkeeping including stopping the thread when STOP or CLOSE are called
+        "GET_PCOMMS": "START|INIT|STOP|RUN_BLOCK",
+    }
+
+    server = DefaultServer(port, ip=ip, pcommand_map=pcommand_map, name="control_room")
+
+    # initialize to start the socket
+    server.init_server(stop_event=stop_event)
+    # start processing of the server
+    logger.info("Server will start listening")
+    server.start_listening()
+
+    return 0
+
+if __name__ == "__main__":
+    logger.setLevel(10)
+    Fire(run_server)

--- a/tests/test_communication.py
+++ b/tests/test_communication.py
@@ -32,7 +32,7 @@ def wait_for_port(host: str = "127.0.0.1", port: int = 9020, timeout: float = 5.
 @pytest.fixture
 def server_process() -> Iterator[subprocess.Popen]:
     proc = subprocess.Popen(
-        [sys.executable, "-m", "tests.resources.tserver"],
+        [sys.executable, "-m", "tests.resources.test_server"],
     )
     # Wait for the server to be ready
     try:
@@ -70,7 +70,7 @@ def test_connection_to_server(server_process):
 @pytest.fixture
 def slow_server_process() -> Iterator[subprocess.Popen]:
     proc = subprocess.Popen(
-        [sys.executable, "-m", "tests.resources.slow_server"],
+        [sys.executable, "-m", "tests.resources.slow_test_server"],
     )
     
     yield proc

--- a/tests/test_communication.py
+++ b/tests/test_communication.py
@@ -1,0 +1,109 @@
+import subprocess
+import sys
+import threading
+import time
+from typing import Iterator
+
+import pytest
+import socket
+
+from dareplane_utils.logging.logger import get_logger
+from dareplane_utils.module_handling.communication import SocketCommunicator
+
+logger = get_logger("testlogger", add_console_handler=True, no_socket_handler=True)
+logger.setLevel(10)
+
+def wait_for_port(host: str = "127.0.0.1", port: int = 9020, timeout: float = 5.0):
+    """Wait until a port is open on the given host, or timeout."""
+    deadline = time.time() + timeout
+    last_err = None
+    while time.time() < deadline:
+        try:
+            with socket.socket() as s:
+                s.settimeout(0.5)
+                s.connect((host, port))
+                s.close()
+                return True
+        except OSError as e:
+            last_err = e
+            time.sleep(0.5)
+    raise TimeoutError(f"Port {host}:{port} not ready: {last_err}")
+
+@pytest.fixture
+def server_process() -> Iterator[subprocess.Popen]:
+    proc = subprocess.Popen(
+        [sys.executable, "-m", "tests.resources.tserver"],
+    )
+    # Wait for the server to be ready
+    try:
+        wait_for_port(port=8080)
+    except TimeoutError as e:
+        proc.terminate()
+        raise RuntimeError("Server failed to start") from e
+    
+    yield proc
+
+    # Teardown
+    if proc.poll() is None:
+        proc.terminate()
+        try:
+            proc.wait(timeout=3)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+
+def test_connection_to_server(server_process):
+    proc = server_process
+    # Connect to the server and send a command
+    sc = SocketCommunicator(ip = "127.0.0.1", port = 8080, name="test")
+    sc.connect()
+
+    assert sc.socket_c is not None
+
+    sc.socket_c.settimeout(2)  # Set a timeout for receiving data
+
+    sc.send(b"UP")
+    response = sc.receive(2048).decode()
+
+    assert response == "1", f"Expected response '1' but got {response}"
+      
+
+@pytest.fixture
+def slow_server_process() -> Iterator[subprocess.Popen]:
+    proc = subprocess.Popen(
+        [sys.executable, "-m", "tests.resources.slow_server"],
+    )
+    
+    yield proc
+
+    # Teardown
+    if proc.poll() is None:
+        proc.terminate()
+        try:
+            proc.wait(timeout=3)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+
+
+def test_retry_connection_after_s_for_slow_startup(slow_server_process):
+    proc = slow_server_process
+
+    # Quick connection should fail
+    with pytest.raises(OSError):
+        sc = SocketCommunicator(ip="127.0.0.1", port=8081, name="test_slow", max_connect_retries=0)
+        sc.connect()
+
+    # slow start-up takes 5 seconds -> 3 seconds for retry with 3 retries should be enough
+    sc = SocketCommunicator(ip="127.0.0.1", port=8081, name="test_slow", max_connect_retries=3, retry_after_s=3)
+
+
+    sc.connect()
+    assert sc.socket_c is not None
+
+    time.sleep(0.5)  # wait a bit to ensure response arrived
+
+    sc.send(b"GET_PCOMMS")
+    pcoms = sc.receive(2048).decode("utf-8")
+    assert pcoms is not None, "Did not receive any response from the server"
+    assert "SLOWSERVERTEST" in pcoms, (
+        f"Did not get the expected pcomms from the server - {pcoms=}"
+    )

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -4,7 +4,7 @@ import time
 
 def test_python_launcher():
     launcher = PythonLauncher(
-        entry_point="tests.resources.tserver",
+        entry_point="tests.resources.test_server",
         cwd=Path(__file__).parent.parent,
     )
     process = launcher.launch()

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -1,0 +1,23 @@
+from dareplane_utils.module_handling.launcher import PythonLauncher
+from pathlib import Path
+import time
+
+def test_python_launcher():
+    launcher = PythonLauncher(
+        entry_point="tests.resources.tserver",
+        cwd=Path(__file__).parent.parent,
+    )
+    process = launcher.launch()
+    time.sleep(2)
+    assert process is not None
+    assert process.poll() is None  # process should be running
+
+    # Teardown
+    launcher.terminate(process)
+    time.sleep(1)
+    assert process.poll() is not None  # process should be terminated
+
+    if process.poll() is None:
+        process.kill()
+
+# TODO: add tests for ExeLauncher

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -13,7 +13,7 @@ def test_python_launcher():
     assert process.poll() is None  # process should be running
 
     # Teardown
-    launcher.terminate(process)
+    launcher.terminate()
     time.sleep(1)
     assert process.poll() is not None  # process should be terminated
 

--- a/tests/test_logging_server_client_communication.py
+++ b/tests/test_logging_server_client_communication.py
@@ -2,7 +2,6 @@ import subprocess
 import time
 from pathlib import Path
 from logging.handlers import SocketHandler
-
 import psutil
 
 from dareplane_utils.logging.logger import get_logger
@@ -11,15 +10,14 @@ from dareplane_utils.logging.logger import get_logger
 class TerminationError(Exception):
     pass
 
-
 def test_opt_out_of_network_logging():
     logger = get_logger("myapp", no_socket_handler=True)
     assert not any([isinstance(h, SocketHandler) for h in logger.handlers])
 
 
 def run_logging_server() -> subprocess.Popen:
-    cmd = "python -m dareplane_utils.logging.server --logfile=dareplane_test.log"
-    return subprocess.Popen(cmd, shell=True)
+    cmd = ["python", "-m", "dareplane_utils.logging.server", "--logfile=dareplane_test.log"]
+    return subprocess.Popen(cmd)
 
 
 def stop_process_and_children(p: psutil.Process):
@@ -48,7 +46,7 @@ def test_logging_server():
     try:
         with run_logging_server() as p_server:
             print(f"Started logging server with PID {p_server.pid}")
-            time.sleep(0.3)
+            time.sleep(1.0)
 
             print("Initializing loggers and sending messages")
             logger1 = get_logger("myapp.area1")
@@ -65,6 +63,7 @@ def test_logging_server():
             logger1.info("info1")
             logger1.warning("warning1")
             logger1.error("error1")
+            time.sleep(0.1)
             logger2.debug("debug2")
             logger2.info("info2")
             logger2.warning("warning2")

--- a/tests/test_module_connection.py
+++ b/tests/test_module_connection.py
@@ -14,7 +14,7 @@ def test_module_connection():
     # Create a module connection with the test server as the target
     connection = ModuleConnection(
         name="test_connection",
-        launcher=PythonLauncher(cwd=Path("."), entry_point="tests.resources.tserver"),
+        launcher=PythonLauncher(cwd=Path("."), entry_point="tests.resources.test_server"),
         communicator=SocketCommunicator(name="test_communicator", ip="127.0.0.1", port=8080),
     )
 
@@ -49,7 +49,7 @@ def test_module_connection_cleanup():
     # Create a module connection with the test server as the target
     connection = ModuleConnection(
         name="test_connection",
-        launcher=PythonLauncher(cwd=Path("."), entry_point="tests.resources.tserver"),
+        launcher=PythonLauncher(cwd=Path("."), entry_point="tests.resources.test_server"),
         communicator=SocketCommunicator(name="test_communicator", ip="127.0.0.1", port=8080),
     )
 

--- a/tests/test_module_connection.py
+++ b/tests/test_module_connection.py
@@ -71,3 +71,32 @@ def test_module_connection_cleanup():
 
         # If the process is still alive, kill it to avoid leaving a dangling process
         proc.kill()
+
+
+def test_python_connection_with_args_and_kwargs():
+    port = 8089
+    cmd_name = "CONFIGURABLESERVERTEST"
+
+    # Create a module connection with the configurable server as the target, passing in args and kwargs to the launcher
+    launcher = PythonLauncher(
+        entry_point="tests.resources.configurable_server",
+        cwd=Path(__file__).parent.parent,
+        args=[str(port), "127.0.0.1"],
+        kwargs={"command_name": cmd_name},
+    )
+    communicator = SocketCommunicator(name="test_communicator", ip="127.0.0.1", port=port)
+
+    conn = ModuleConnection(
+        name="test_connection",
+        launcher=launcher,
+        communicator=communicator,
+    )
+    conn.start()
+    time.sleep(2)
+
+    conn.send_message(b"GET_PCOMMS")
+    pcomms = conn.receive_message(size=2048).decode()
+
+    assert cmd_name in pcomms
+
+    conn.stop()

--- a/tests/test_module_connection.py
+++ b/tests/test_module_connection.py
@@ -1,0 +1,73 @@
+import time
+from pathlib import Path
+import subprocess
+import pytest
+import psutil
+import os
+
+from dareplane_utils.module_handling.module_connection import ModuleConnection
+from dareplane_utils.module_handling.launcher import PythonLauncher
+from dareplane_utils.module_handling.communication import SocketCommunicator
+
+
+def test_module_connection():
+    # Create a module connection with the test server as the target
+    connection = ModuleConnection(
+        name="test_connection",
+        launcher=PythonLauncher(cwd=Path("."), entry_point="tests.resources.tserver"),
+        communicator=SocketCommunicator(name="test_communicator", ip="127.0.0.1", port=8080),
+    )
+
+    connection.start()
+    # Wait for the connection to be established
+    time.sleep(2)
+
+    # Check that the connection is alive
+    pid = connection.process.pid
+    assert pid is not None
+    assert connection.process.poll() is None
+    assert connection.communicator.socket_c is not None
+
+    connection.send_message(b"UP")
+    response = connection.receive_message(size=2048)
+    assert response.decode() == "1"
+
+    # Stop the connection and check that the process is terminated
+    connection.stop()
+    time.sleep(1)
+    assert connection.process is None
+
+    # Check that the pid is not running anymore
+    with pytest.raises(psutil.NoSuchProcess):
+        proc = psutil.Process(pid)
+
+        # If the process is still alive, kill it to avoid leaving a dangling process
+        proc.kill()
+
+    
+def test_module_connection_cleanup():
+    # Create a module connection with the test server as the target
+    connection = ModuleConnection(
+        name="test_connection",
+        launcher=PythonLauncher(cwd=Path("."), entry_point="tests.resources.tserver"),
+        communicator=SocketCommunicator(name="test_communicator", ip="127.0.0.1", port=8080),
+    )
+
+    # Connect
+    connection.start()
+    time.sleep(2)
+
+    pid = connection.process.pid
+    assert pid is not None
+    assert connection.process.poll() is None
+
+    # Delete the connection object without explicitly stopping it, and check that the process is terminated
+    del connection
+    time.sleep(1)
+
+    # Check that the pid is not running anymore
+    with pytest.raises(psutil.NoSuchProcess):
+        proc = psutil.Process(pid)
+
+        # If the process is still alive, kill it to avoid leaving a dangling process
+        proc.kill()

--- a/tests/test_module_connection.py
+++ b/tests/test_module_connection.py
@@ -23,9 +23,9 @@ def test_module_connection():
     time.sleep(2)
 
     # Check that the connection is alive
-    pid = connection.process.pid
+    pid = connection.launcher.process.pid
     assert pid is not None
-    assert connection.process.poll() is None
+    assert connection.launcher.process.poll() is None
     assert connection.communicator.socket_c is not None
 
     connection.send_message(b"UP")
@@ -35,7 +35,7 @@ def test_module_connection():
     # Stop the connection and check that the process is terminated
     connection.stop()
     time.sleep(1)
-    assert connection.process is None
+    assert connection.launcher.process is None
 
     # Check that the pid is not running anymore
     with pytest.raises(psutil.NoSuchProcess):
@@ -57,9 +57,9 @@ def test_module_connection_cleanup():
     connection.start()
     time.sleep(2)
 
-    pid = connection.process.pid
+    pid = connection.launcher.process.pid
     assert pid is not None
-    assert connection.process.poll() is None
+    assert connection.launcher.process.poll() is None
 
     # Delete the connection object without explicitly stopping it, and check that the process is terminated
     del connection


### PR DESCRIPTION
This replaces and extends functionality that was previously in dp-control-room, such that it can also be used in other dp modules (e.g. starting LSL in dp-lsl-recording).

Currently this implements:
- Launching Python or .exe programs (.exe launching still needs testing)
  - For python programs, users can define working directory, entry point, python instance
- Communicating via TCP

but more launch types and communication methods can be added easily.

@matthiasdold I am not sure what to do with the pcomms. Currently, these can be optionally defined in the config, or else they are requested through `ModuleConnection.get_pcommands()', which is currently called for every module. However, I suppose such pcomms are only/mainly used by dareplane-modules, not necessarily by user-defined python modules or other executables. How do you want to deal with this? 

Also, let me know if you have any thoughts on the design or specific features.